### PR TITLE
Add script to generate dataset PDFs

### DIFF
--- a/DocQualityChecker/DocQualityChecker.csproj
+++ b/DocQualityChecker/DocQualityChecker.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="PDFtoImage" Version="5.1.1" />
     <PackageReference Include="SkiaSharp" Version="3.119.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Questa libreria fornisce semplici controlli di qualità su immagini di documenti tramite API gestite.
 L'implementazione utilizza [SkiaSharp](https://github.com/mono/SkiaSharp) per la manipolazione delle immagini.
+È inoltre possibile analizzare documenti **PDF** grazie alla libreria [PDFtoImage](https://www.nuget.org/packages/PDFtoImage). Il metodo `CheckQuality(Stream, QualitySettings, int? pageIndex)` elabora la singola pagina indicata o, in assenza di parametro, tutte le pagine del file.
 
 ## Requisiti
 
@@ -69,8 +70,14 @@ Il progetto `DocQualityChecker.Api` espone un endpoint `POST /quality/check` per
 eseguire i controlli via HTTP. L'input è un form con i campi:
 
 - `image` (file) immagine da analizzare
+- `pdf` (file, opzionale) documento PDF da cui estrarre le pagine
+- `pageIndex` (opzionale) indice della pagina PDF da elaborare. Se omesso sono
+  processate tutte le pagine
 - `checks` (opzionale) lista di controlli da eseguire
 - `settings` (opzionale) oggetto `QualitySettings` per personalizzare le soglie
+
+Quando viene caricato un file PDF l'endpoint restituisce un array di risultati,
+uno per ciascuna pagina elaborata.
 
 Se `settings.generateHeatmaps` è impostato a `true` la risposta includerà le
 mappe di calore in formato base64 (`BlurHeatmap` e `GlareHeatmap`) e le
@@ -156,6 +163,12 @@ python download_datasets.py
 ```
 
 Lo script salva le cartelle `glare_dataset` e `blur_dataset`. Da queste è sufficiente prelevare alcune immagini (massimo 20) da analizzare con il programma `DatasetEvaluator` che stampa i valori calcolati e salva la heatmap accanto all'immagine esaminata:
+
+Per generare documenti PDF a partire dalle immagini presenti in `docs/dataset_samples` è disponibile lo script `generate_dataset_pdfs.py`:
+
+```bash
+python generate_dataset_pdfs.py
+```
 
 Dopo aver estratto le immagini, è disponibile il programma `DatasetEvaluator` che stampa i valori calcolati dalla libreria e salva la mappa di calore dei riflessi accanto all'immagine esaminata:
 

--- a/generate_dataset_pdfs.py
+++ b/generate_dataset_pdfs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate PDF files from the sample dataset images.
+
+This script collects all JPEG and PNG images under ``docs/dataset_samples``
+and creates one PDF per subdirectory. The resulting files are saved in the
+``generated_pdfs`` folder or in a custom directory passed via command line.
+
+Usage::
+
+    python generate_dataset_pdfs.py [output_dir]
+
+Dependencies::
+
+    pip install pillow
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Iterable
+
+from PIL import Image
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATASET_DIR = os.path.join(ROOT_DIR, "docs", "dataset_samples")
+
+
+def list_images(folder: str) -> Iterable[str]:
+    """Yield absolute paths of JPEG/PNG images in ``folder`` sorted by name."""
+    for name in sorted(os.listdir(folder)):
+        if name.lower().endswith((".jpg", ".jpeg", ".png")):
+            yield os.path.join(folder, name)
+
+
+def images_to_pdf(images: Iterable[str], output: str) -> bool:
+    """Save ``images`` into a multipage PDF located at ``output``."""
+    pages = [Image.open(path).convert("RGB") for path in images]
+    if not pages:
+        return False
+    first, rest = pages[0], pages[1:]
+    first.save(output, save_all=True, append_images=rest)
+    for img in pages:
+        img.close()
+    return True
+
+
+def convert_dataset(out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    for item in os.listdir(DATASET_DIR):
+        folder = os.path.join(DATASET_DIR, item)
+        if not os.path.isdir(folder):
+            continue
+        images = list(list_images(folder))
+        if not images:
+            continue
+        out_pdf = os.path.join(out_dir, f"{item}.pdf")
+        if images_to_pdf(images, out_pdf):
+            print(f"Created {out_pdf}")
+
+
+def main() -> None:
+    out_dir = sys.argv[1] if len(sys.argv) > 1 else "generated_pdfs"
+    convert_dataset(out_dir)
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_dataset_pdfs.py` for creating PDFs from the dataset images
- document script usage in README

## Testing
- `bash dotnet-install.sh -InstallDir "$HOME/dotnet" -Version 9.0.303`
- `dotnet test DocQualityChecker.Tests/DocQualityChecker.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688a45ab7ae88325b21b11228fa3cd21