### PR TITLE
feat: add heatmap option to results page

### DIFF
--- a/DocQualityChecker.Api.Tests/IndexModelTests.cs
+++ b/DocQualityChecker.Api.Tests/IndexModelTests.cs
@@ -64,6 +64,32 @@ public class IndexModelTests
         Assert.IsType<PageResult>(actionResult);
         Assert.True(model.ModelState.IsValid);
         Assert.NotNull(model.Result);
+        Assert.Null(model.BlurHeatmap);
+        Assert.Null(model.GlareHeatmap);
+    }
+
+    [Fact]
+    public void OnPost_WithHeatmaps_GeneratesImages()
+    {
+        var model = CreateModel();
+        model.Settings.GenerateHeatmaps = true;
+
+        using var bmp = CreateBaseImage();
+        using var img = SKImage.FromBitmap(bmp);
+        using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+        using var ms = new MemoryStream();
+        data.SaveTo(ms);
+        ms.Position = 0;
+
+        model.Image = new FormFile(ms, 0, ms.Length, "Image", "test.png");
+
+        var actionResult = model.OnPost();
+
+        Assert.IsType<PageResult>(actionResult);
+        Assert.True(model.ModelState.IsValid);
+        Assert.NotNull(model.Result);
+        Assert.False(string.IsNullOrEmpty(model.BlurHeatmap));
+        Assert.False(string.IsNullOrEmpty(model.GlareHeatmap));
     }
 }
 

--- a/DocQualityChecker.Api/Pages/Index.cshtml
+++ b/DocQualityChecker.Api/Pages/Index.cshtml
@@ -46,6 +46,10 @@
             <input class="form-control" asp-for="Image" type="file" />
             <span class="text-danger" asp-validation-for="Image"></span>
         </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" asp-for="Settings.GenerateHeatmaps" />
+            <label class="form-check-label" asp-for="Settings.GenerateHeatmaps">Generate heatmaps</label>
+        </div>
         <div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
             <div class="col">
                 <label asp-for="Settings.BrisqueMax" class="form-label">BRISQUE max

--- a/DocQualityChecker.Api/Pages/Index.cshtml.cs
+++ b/DocQualityChecker.Api/Pages/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using System;
 using DocQualityChecker;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -16,6 +17,8 @@ public class IndexModel : PageModel
     public QualitySettings Settings { get; } = new();
 
     public DocumentQualityResult? Result { get; private set; }
+    public string? BlurHeatmap { get; private set; }
+    public string? GlareHeatmap { get; private set; }
 
     public IActionResult OnPost()
     {
@@ -28,6 +31,23 @@ public class IndexModel : PageModel
         using var stream = Image.OpenReadStream();
         using var bitmap = SKBitmap.Decode(stream);
         Result = _checker.CheckQuality(bitmap, Settings);
+
+        if (Settings.GenerateHeatmaps)
+        {
+            if (Result.BlurHeatmap != null)
+            {
+                using var img = SKImage.FromBitmap(Result.BlurHeatmap);
+                using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+                BlurHeatmap = "data:image/png;base64," + Convert.ToBase64String(data.ToArray());
+            }
+            if (Result.GlareHeatmap != null)
+            {
+                using var img = SKImage.FromBitmap(Result.GlareHeatmap);
+                using var data = img.Encode(SKEncodedImageFormat.Png, 100);
+                GlareHeatmap = "data:image/png;base64," + Convert.ToBase64String(data.ToArray());
+            }
+        }
+
         return Page();
     }
 }

--- a/DocQualityChecker.Api/Pages/_Result.cshtml
+++ b/DocQualityChecker.Api/Pages/_Result.cshtml
@@ -35,6 +35,10 @@
                             </tr>
                         </tbody>
                     </table>
+                    @if (Model.Settings.GenerateHeatmaps && !string.IsNullOrEmpty(Model.BlurHeatmap))
+                    {
+                        <img class="img-fluid mt-3" src="@Model.BlurHeatmap" alt="Blur heatmap" />
+                    }
                 </div>
             </div>
         </div>
@@ -69,6 +73,10 @@
                             </tr>
                         </tbody>
                     </table>
+                    @if (Model.Settings.GenerateHeatmaps && !string.IsNullOrEmpty(Model.GlareHeatmap))
+                    {
+                        <img class="img-fluid mt-3" src="@Model.GlareHeatmap" alt="Glare heatmap" />
+                    }
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add checkbox to enable heatmap generation when analyzing documents
- show blur and glare heatmaps within their respective result cards
- cover heatmap flow with page model tests

## Testing
- `dotnet test DocQualityChecker.Tests/DocQualityChecker.Tests.csproj`
- `dotnet test DocQualityChecker.Api.Tests/DocQualityChecker.Api.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688fa14c85088325897b22e4a2261099